### PR TITLE
[WIP] Helix keyboard Compile time OLED, RGBLIGHT on/off control

### DIFF
--- a/keyboards/helix/rev2/keymaps/default/config.h
+++ b/keyboards/helix/rev2/keymaps/default/config.h
@@ -74,7 +74,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #elif RGBLED == 1
   #define RGBLED_NUM 6
 #elif RGBLED == 2
-  #define RGBLED_NUM 32
+  #if HELIX_ROWS == 5
+    #define RGBLED_NUM 32
+  #else
+    #define RGBLED_NUM 25
+  #endif
 #endif
 
 #if RGBLED_NUM <= 6

--- a/keyboards/helix/rev2/keymaps/default/config.h
+++ b/keyboards/helix/rev2/keymaps/default/config.h
@@ -67,17 +67,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #undef RGBLED_NUM
-#define RGBLIGHT_ANIMATIONS
-// Helix keyboard : see ./rules.mk: RGBLED=back or RGBLED=under
+// Helix keyboard :
+//    see ./rules.mk: LED=back  or LED=backna or
+//                    LED=under or LED=underna
 #ifndef RGBLED
+  #define RGBLIGHT_ANIMATIONS
   #define RGBLED_NUM 6
-#elif RGBLED == 1
-  #define RGBLED_NUM 6
-#elif RGBLED == 2
-  #if HELIX_ROWS == 5
-    #define RGBLED_NUM 32
-  #else
-    #define RGBLED_NUM 25
+#else
+  #if RGBLED == 1 || RGBLED == 3
+    #define RGBLIGHT_ANIMATIONS
+  #endif
+  #if RGBLED == 1 || RGBLED == 2
+    #define RGBLED_NUM 6
+  #elif RGBLED == 3 || RGBLED == 4
+    #if HELIX_ROWS == 5
+      #define RGBLED_NUM 32
+    #else
+      #define RGBLED_NUM 25
+    #endif
   #endif
 #endif
 

--- a/keyboards/helix/rev2/keymaps/default/config.h
+++ b/keyboards/helix/rev2/keymaps/default/config.h
@@ -36,7 +36,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #define EE_HANDS
 
 // Helix keyboard OLED support
-//#define SSD1306OLED
+//      see ./rules.mk: OLED=yes
+#ifdef OLED_ENABLE
+  #define SSD1306OLED
+#endif
 
 /* Select rows configuration */
 // Rows are 4 or 5
@@ -65,9 +68,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #undef RGBLED_NUM
 #define RGBLIGHT_ANIMATIONS
-// Helix keyboard : see ./rules.mk: RGBLIGHT_ENABLE = yes or no
-// Helix keyboard : RGBLED_NUM 6 or 32
-#define RGBLED_NUM 6
+// Helix keyboard : see ./rules.mk: RGBLED=back or RGBLED=under
+#ifndef RGBLED
+  #define RGBLED_NUM 6
+#elif RGBLED == 1
+  #define RGBLED_NUM 6
+#elif RGBLED == 2
+  #define RGBLED_NUM 32
+#endif
+
 #if RGBLED_NUM <= 6
   #define RGBLIGHT_LIMIT_VAL 255
 #else

--- a/keyboards/helix/rev2/keymaps/default/rules.mk
+++ b/keyboards/helix/rev2/keymaps/default/rules.mk
@@ -15,25 +15,60 @@ AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 # Helix keyboard :
-#     RGB off       : make helix/default
-#     RGB backlight : make RGBLED=back helix/default
-#     RGB underglow : make RGBLED=under helix/default
-ifneq ($(filter back under,$(RGBLED)),)
+#     LED off                 : make helix:default
+#     LED backlight           : make LED=back   helix:default
+#           and no animations : make LED=backna helix:default
+#     LED underglow           : make LED=under   helix:default
+#           and no animetions : make LED=underna helix:default
+#  see ./config.h
+RGBLED := $(filter back backna under underna,$(LED) $(RGBLED))
+ifeq ($(RGBLED),)
+  ifneq ($(LED),)
+    $(warning === Unknown keyword! : LED=$(LED) ===)
+    $(error try : make helix:default:help ***)
+  endif
+endif
+ifneq ($(RGBLED),)
   RGBLIGHT_ENABLE = yes   # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
-  ifeq ($(strip $(RGBLED)), back)
-    OPT_DEFS += -DRGBLED=2
-  else
+  ifeq ($(strip $(RGBLED)), under)
     OPT_DEFS += -DRGBLED=1
+  endif
+  ifeq ($(strip $(RGBLED)), underna)
+    OPT_DEFS += -DRGBLED=2
+  endif
+  ifeq ($(strip $(RGBLED)), back)
+    OPT_DEFS += -DRGBLED=3
+  endif
+  ifeq ($(strip $(RGBLED)), backna)
+    OPT_DEFS += -DRGBLED=4
   endif
 endif
 ONEHAND_ENABLE = no        # Enable one-hand typing
 
 # Helix keyboard :
-#     OLED off  : make helix/default
-#     OLED on   : make OLED=yes helix/default
-ifeq ($(strip $(OLED)), yes)
+#     OLED off  : make helix:default
+#     OLED on   : make OLED=yes helix:default
+OLEDSW := $(filter yes on,$(OLED))
+ifneq ($(strip $(OLEDSW)),)
     OPT_DEFS += -DOLED_ENABLE
+else
+  ifneq ($(OLED),)
+    $(warning === Unknown keyword! : OLED=$(OLED) ===)
+    $(error try : make helix:default:help ***)
+  endif
 endif
+
+help:
+	echo "OLED off, RGBRIGHT off:       $$ make helix:default"
+	echo "OLED on,  RGBRIGHT off:       $$ make OLED=yes    helix:default"
+	echo "OLED off, RGBRIGHT underglow: $$ make LED=under   helix:default"
+	echo "        and no animation    : $$ make LED=underna helix:default"
+	echo "OLED off, RGBRIGHT backlight: $$ make LED=back    helix:default"
+	echo "        and no animation    : $$ make LED=backna  helix:default"
+	echo "OLED on,  RGBRIGHT backlight: $$ make OLED=yes LED=back   helix:default"
+	echo "        and no animation    : $$ make OLED=yes LED=backna helix:default"
+	echo ""
+	exit 0
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/helix/rev2/keymaps/default/rules.mk
+++ b/keyboards/helix/rev2/keymaps/default/rules.mk
@@ -14,10 +14,26 @@ MIDI_ENABLE = no            # MIDI controls
 AUDIO_ENABLE = no           # Audio output on port C6
 UNICODE_ENABLE = no         # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
-# Helix keyboard : see ./config.h: RGBLED_NUM 6 or 32
-# Helix keyboard : RGBLIGHT_ENABLE = no or yes
-RGBLIGHT_ENABLE = no        # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+# Helix keyboard :
+#     RGB off       : make helix/default
+#     RGB backlight : make RGBLED=back helix/default
+#     RGB underglow : make RGBLED=under helix/default
+ifneq ($(filter back under,$(RGBLED)),)
+  RGBLIGHT_ENABLE = yes   # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
+  ifeq ($(strip $(RGBLED)), back)
+    OPT_DEFS += -DRGBLED=2
+  else
+    OPT_DEFS += -DRGBLED=1
+  endif
+endif
 ONEHAND_ENABLE = no        # Enable one-hand typing
+
+# Helix keyboard :
+#     OLED off  : make helix/default
+#     OLED on   : make OLED=yes helix/default
+ifeq ($(strip $(OLED)), yes)
+    OPT_DEFS += -DOLED_ENABLE
+endif
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend


### PR DESCRIPTION
相談しながら詰めていきたいので、[WIP] 付けてます。
(WIP = Work In Progress、未完成の状態でプルリクエストを出して
 GitHub 上でコメントのやりとりをしながら、プルリクエストを完成させていくやり方だそうです。 試しに実行してみます。)

以下のようにコンパイル時に make コマンドのオプションによって、OLED の有る無し、
RGBLED の個数を指定できるようにする改造です。
生成されるファームのバイナリは従来通りです。

```
 $ make helix/default                       -- OLED off, RGBRIGHT off
 $ make OLED=yes helix/default              -- OLED on, RGBRIGHT off
 $ make RGBLED=under helix/default          -- OLED off, RGBRIGHT underglow
 $ make RGBLED=back helix/default           -- OLED off, RGBRIGHT backlight
 $ make OLED=yes RGBLED=back helix/default  -- OLED on, RGBRIGHT backlight
```
この方法、いかがでしょうか？
