### PR TITLE
Helix custom OLED font file for each keymap 

### DIFF
--- a/keyboards/helix/rev2/keymaps/default/rules.mk
+++ b/keyboards/helix/rev2/keymaps/default/rules.mk
@@ -26,10 +26,11 @@ define HELIX_CUSTOMISE_MSG
 endef
 
 # Helix keyboard customize
-# you can edit follows 5 Variables
-#  jp: 以下の5つの変数を必要に応じて編集します。
+# you can edit follows 6 Variables
+#  jp: 以下の6つの変数を必要に応じて編集します。
 HELIX_ROWS = 5              # Helix Rows is 4 or 5
 OLED_ENABLE = no            # OLED_ENABLE
+LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" insted of "common/glcdfont.c"
 LED_BACK_ENABLE = no        # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations
@@ -68,6 +69,10 @@ endif
 
 ifeq ($(strip $(OLED_ENABLE)), yes)
     OPT_DEFS += -DOLED_ENABLE
+endif
+
+ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
+    OPT_DEFS += -DLOCAL_GLCDFONT
 endif
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE

--- a/keyboards/helix/rev2/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows/rules.mk
@@ -27,9 +27,10 @@ define HELIX_CUSTOMISE_MSG
 endef
 
 # Helix keyboard customize
-# you can edit follows 5 Variables
-#  jp: 以下の5つの変数を必要に応じて編集します。
+# you can edit follows 6 Variables
+#  jp: 以下の6つの変数を必要に応じて編集します。
 OLED_ENABLE = no            # OLED_ENABLE
+LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" insted of "common/glcdfont.c"
 LED_BACK_ENABLE = no        # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations
@@ -95,6 +96,10 @@ endif
 
 ifeq ($(strip $(OLED_ENABLE)), yes)
     OPT_DEFS += -DOLED_ENABLE
+endif
+
+ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
+    OPT_DEFS += -DLOCAL_GLCDFONT
 endif
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE

--- a/keyboards/helix/ssd1306.c
+++ b/keyboards/helix/ssd1306.c
@@ -4,7 +4,11 @@
 #include "i2c.h"
 #include <string.h>
 #include "print.h"
+#ifndef LOCAL_GLCDFONT
 #include "common/glcdfont.c"
+#else
+#include <helixfont.h>
+#endif
 #ifdef ADAFRUIT_BLE_ENABLE
 #include "adafruit_ble.h"
 #endif


### PR DESCRIPTION
* change helix/ssd1306.c
  select include file "common/glcdfont.c" or <helixfont.h>
* change default/rules.mk, five_rows/rules.mk
  add customize variable LOCAL_GLCDFONT for helix/ssd1306.c
