### PR TITLE
Add iPhone/iPad LED support to Helix default keymap

### DIFF
--- a/keyboards/helix/rev2/keymaps/default/config.h
+++ b/keyboards/helix/rev2/keymaps/default/config.h
@@ -78,30 +78,44 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   #define RGBLED_NUM 6
 #endif
 
-#if RGBLED_NUM <= 6
-  #define RGBLIGHT_LIMIT_VAL 255
-#else
-  #if HELIX_ROWS == 5
-    #define RGBLIGHT_LIMIT_VAL 120
+#ifndef IOS_DEVICE_ENABLE
+  #if RGBLED_NUM <= 6
+    #define RGBLIGHT_LIMIT_VAL 255
   #else
-    #define RGBLIGHT_LIMIT_VAL 130
+    #if HELIX_ROWS == 5
+      #define RGBLIGHT_LIMIT_VAL 120
+    #else
+      #define RGBLIGHT_LIMIT_VAL 130
+    #endif
   #endif
+  #define RGBLIGHT_VAL_STEP 17
+#else
+  #if RGBLED_NUM <= 6
+    #define RGBLIGHT_LIMIT_VAL 90
+  #else
+    #if HELIX_ROWS == 5
+      #define RGBLIGHT_LIMIT_VAL 35
+    #else
+      #define RGBLIGHT_LIMIT_VAL 45
+    #endif
+  #endif
+  #define RGBLIGHT_VAL_STEP 4
 #endif
 #define RGBLIGHT_HUE_STEP 10
 #define RGBLIGHT_SAT_STEP 17
-#define RGBLIGHT_VAL_STEP 17
-#endif
 
-#ifdef RGBLIGHT_ENABLE
+#if defined(RGBLIGHT_ENABLE) && !defined(IOS_DEVICE_ENABLE)
 // USB_MAX_POWER_CONSUMPTION value for Helix keyboard
 //  120  RGBoff, OLEDoff
 //  120  OLED
 //  330  RGB 6
 //  300  RGB 32
 //  310  OLED & RGB 32
-  #define USB_MAX_POWER_CONSUMPTION 330
+  #define USB_MAX_POWER_CONSUMPTION 400
 #else
   // fix iPhone and iPad power adapter issue
   // iOS device need lessthan 100
   #define USB_MAX_POWER_CONSUMPTION 100
 #endif
+
+#endif /* CONFIG_USER_H */

--- a/keyboards/helix/rev2/keymaps/default/readme.md
+++ b/keyboards/helix/rev2/keymaps/default/readme.md
@@ -109,13 +109,15 @@ see `qmk_firmware/keyboards/helix/rev2/keymaps/default/rules.mk`
 
 ```
 # Helix keyboard customize
-# you can edit follows 5 Variables
-#  jp: 以下の5つの変数を必要に応じて編集します。
+# you can edit follows 7 Variables
+#  jp: 以下の7つの変数を必要に応じて編集します。
 HELIX_ROWS = 5              # Helix Rows is 4 or 5
 OLED_ENABLE = no            # OLED_ENABLE
+LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" insted of "common/glcdfont.c"
 LED_BACK_ENABLE = no        # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations
+IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
 
 ```
 ## Compile

--- a/keyboards/helix/rev2/keymaps/default/readme_jp.md
+++ b/keyboards/helix/rev2/keymaps/default/readme_jp.md
@@ -52,13 +52,15 @@ RGB バックライトまたは、RGB Underglow をつけた場合は、
 
 ```
 # Helix keyboard customize
-# you can edit follows 5 Variables
-#  jp: 以下の5つの変数を必要に応じて編集します。
+# you can edit follows 7 Variables
+#  jp: 以下の7つの変数を必要に応じて編集します。
 HELIX_ROWS = 5              # Helix Rows is 4 or 5
 OLED_ENABLE = no            # OLED_ENABLE
+LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" insted of "common/glcdfont.c"
 LED_BACK_ENABLE = no        # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations
+IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
 
 ```
 
@@ -90,6 +92,15 @@ LED_UNDERGLOW_ENABLE = yes   # LED underglow (Enable WS2812 RGB underlight.)
 rules.mk の下記の部分を編集して no を yes に変更してください。
 ```
 OLED_ENABLE = yes            # OLED_ENABLE
+```
+
+## iPad/iPhoneサポートを有効にする。
+
+rules.mk の下記の部分を編集して no を yes に変更してください。
+RBG Underglow や RGBバックライトの輝度を抑えて、iPad, iPhone にも接続できるようになります。
+
+```
+IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
 ```
 
 ## リンク

--- a/keyboards/helix/rev2/keymaps/default/rules.mk
+++ b/keyboards/helix/rev2/keymaps/default/rules.mk
@@ -23,20 +23,51 @@ define HELIX_CUSTOMISE_MSG
   $(info -  LED_BACK_ENABLE=$(LED_BACK_ENABLE))
   $(info -  LED_UNDERGLOW_ENABLE=$(LED_UNDERGLOW_ENABLE))
   $(info -  LED_ANIMATION=$(LED_ANIMATIONS))
+  $(info -  IOS_DEVICE_ENABLE=$(IOS_DEVICE_ENABLE))
 endef
 
 # Helix keyboard customize
-# you can edit follows 6 Variables
-#  jp: 以下の6つの変数を必要に応じて編集します。
+# you can edit follows 7 Variables
+#  jp: 以下の7つの変数を必要に応じて編集します。
 HELIX_ROWS = 5              # Helix Rows is 4 or 5
 OLED_ENABLE = no            # OLED_ENABLE
 LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" insted of "common/glcdfont.c"
 LED_BACK_ENABLE = no        # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations
+IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
 
 ####  LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE.
 ####    Do not enable these with audio at the same time.
+
+### Helix keyboard 'default' keymap: convenient command line option
+##    make HELIX=<options> helix:defualt
+##    option= oled | back | under | na | ios
+##    ex.
+##      make HELIX=oled          helix:defualt
+##      make HELIX=oled,back     helix:defualt
+##      make HELIX=oled,under    helix:defualt
+##      make HELIX=oled,back,na  helix:defualt
+##      make HELIX=oled,back,ios helix:defualt
+##
+ifneq ($(strip $(HELIX)),)
+  ifeq ($(findstring oled,$(HELIX)), oled)
+    OLED_ENABLE = yes
+  endif
+  ifeq ($(findstring back,$(HELIX)), back)
+    LED_BACK_ENABLE = yes
+  else ifeq ($(findstring under,$(HELIX)), under)
+    LED_UNDERGLOW_ENABLE = yes
+  endif
+  ifeq ($(findstring na,$(HELIX)), na)
+    LED_ANIMATIONS = no
+  endif
+  ifeq ($(findstring ios,$(HELIX)), ios)
+    IOS_DEVICE_ENABLE = yes
+  endif
+  $(eval $(call HELIX_CUSTOMISE_MSG))
+  $(info )
+endif
 
 # Uncomment these for checking
 #   jp: コンパイル時にカスタマイズの状態を表示したい時はコメントをはずします。
@@ -61,6 +92,10 @@ else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
   RGBLIGHT_ENABLE = yes
 else
   RGBLIGHT_ENABLE = no
+endif
+
+ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
+    OPT_DEFS += -DIOS_DEVICE_ENABLE
 endif
 
 ifeq ($(strip $(LED_ANIMATIONS)), yes)


### PR DESCRIPTION
iPhone, iPad を接続した時にも LED を有効にできるように、電力制限内で済むような輝度制限を設定するオプションを用意しました。
