### PR TITLE
Helix keymaps rules.mk refine

### DIFF
--- a/keyboards/helix/pico/keymaps/biacco/rules.mk
+++ b/keyboards/helix/pico/keymaps/biacco/rules.mk
@@ -40,81 +40,17 @@ Link_Time_Optimization = no # if firmware size over limit, try this option
 ####  LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE.
 ####    Do not enable these with audio at the same time.
 
-### Helix keyboard 'default' keymap: convenient command line option
-##    make HELIX=<options> helix:defualt
+### Helix Pico keyboard 'biacco' keymap: convenient command line option
+##    make HELIX=<options> helix/pico:biacco
 ##    option= oled | back | under | na | ios
 ##    ex.
-##      make HELIX=oled          helix:defualt
-##      make HELIX=oled,back     helix:defualt
-##      make HELIX=oled,under    helix:defualt
-##      make HELIX=oled,back,na  helix:defualt
-##      make HELIX=oled,back,ios helix:defualt
+##      make HELIX=oled          helix/pico:biacco
+##      make HELIX=oled,back     helix/pico:biacco
+##      make HELIX=oled,under    helix/pico:biacco
+##      make HELIX=oled,back,na  helix/pico:biacco
+##      make HELIX=oled,back,ios helix/pico:biacco
 ##
-ifneq ($(strip $(HELIX)),)
-  ifeq ($(findstring oled,$(HELIX)), oled)
-    OLED_ENABLE = yes
-  endif
-  ifeq ($(findstring back,$(HELIX)), back)
-    LED_BACK_ENABLE = yes
-  else ifeq ($(findstring under,$(HELIX)), under)
-    LED_UNDERGLOW_ENABLE = yes
-  endif
-  ifeq ($(findstring na,$(HELIX)), na)
-    LED_ANIMATIONS = no
-  endif
-  ifeq ($(findstring ios,$(HELIX)), ios)
-    IOS_DEVICE_ENABLE = yes
-  endif
-  $(eval $(call HELIX_CUSTOMISE_MSG))
-  $(info )
-endif
-
-# Uncomment these for checking
-#   jp: コンパイル時にカスタマイズの状態を表示したい時はコメントをはずします。
-# $(eval $(call HELIX_CUSTOMISE_MSG))
-# $(info )
-
-ifeq ($(strip $(LED_BACK_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-  OPT_DEFS += -DRGBLED_BACK
-  ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-    $(eval $(call HELIX_CUSTOMISE_MSG))
-    $(error LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE both 'yes')
-  endif
-else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-else
-  RGBLIGHT_ENABLE = no
-endif
-
-ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
-    OPT_DEFS += -DIOS_DEVICE_ENABLE
-endif
-
-ifeq ($(strip $(LED_ANIMATIONS)), yes)
-    OPT_DEFS += -DRGBLIGHT_ANIMATIONS
-endif
-
-ifeq ($(strip $(OLED_ENABLE)), yes)
-    OPT_DEFS += -DOLED_ENABLE
-endif
-
-ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
-    OPT_DEFS += -DLOCAL_GLCDFONT
-endif
-
-ifeq ($(strip $(AUDIO_ENABLE)),yes)
-  ifeq ($(strip $(RGBLIGHT_ENABLE)),yes)
-    Link_Time_Optimization = yes
-  endif
-  ifeq ($(strip $(OLED_ENABLE)),yes)
-    Link_Time_Optimization = yes
-  endif
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-    EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
-endif
+include $(dir $(lastword $(MAKEFILE_LIST)))../../keymaps_common.mk
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/helix/pico/keymaps/default/rules.mk
+++ b/keyboards/helix/pico/keymaps/default/rules.mk
@@ -40,81 +40,17 @@ Link_Time_Optimization = no # if firmware size over limit, try this option
 ####  LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE.
 ####    Do not enable these with audio at the same time.
 
-### Helix keyboard 'default' keymap: convenient command line option
-##    make HELIX=<options> helix:defualt
+### Helix Pico keyboard 'default' keymap: convenient command line option
+##    make HELIX=<options> helix/pico:default
 ##    option= oled | back | under | na | ios
 ##    ex.
-##      make HELIX=oled          helix:defualt
-##      make HELIX=oled,back     helix:defualt
-##      make HELIX=oled,under    helix:defualt
-##      make HELIX=oled,back,na  helix:defualt
-##      make HELIX=oled,back,ios helix:defualt
+##      make HELIX=oled          helix/pico:default
+##      make HELIX=oled,back     helix/pico:default
+##      make HELIX=oled,under    helix/pico:default
+##      make HELIX=oled,back,na  helix/pico:default
+##      make HELIX=oled,back,ios helix/pico:default
 ##
-ifneq ($(strip $(HELIX)),)
-  ifeq ($(findstring oled,$(HELIX)), oled)
-    OLED_ENABLE = yes
-  endif
-  ifeq ($(findstring back,$(HELIX)), back)
-    LED_BACK_ENABLE = yes
-  else ifeq ($(findstring under,$(HELIX)), under)
-    LED_UNDERGLOW_ENABLE = yes
-  endif
-  ifeq ($(findstring na,$(HELIX)), na)
-    LED_ANIMATIONS = no
-  endif
-  ifeq ($(findstring ios,$(HELIX)), ios)
-    IOS_DEVICE_ENABLE = yes
-  endif
-  $(eval $(call HELIX_CUSTOMISE_MSG))
-  $(info )
-endif
-
-# Uncomment these for checking
-#   jp: コンパイル時にカスタマイズの状態を表示したい時はコメントをはずします。
-# $(eval $(call HELIX_CUSTOMISE_MSG))
-# $(info )
-
-ifeq ($(strip $(LED_BACK_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-  OPT_DEFS += -DRGBLED_BACK
-  ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-    $(eval $(call HELIX_CUSTOMISE_MSG))
-    $(error LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE both 'yes')
-  endif
-else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-else
-  RGBLIGHT_ENABLE = no
-endif
-
-ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
-    OPT_DEFS += -DIOS_DEVICE_ENABLE
-endif
-
-ifeq ($(strip $(LED_ANIMATIONS)), yes)
-    OPT_DEFS += -DRGBLIGHT_ANIMATIONS
-endif
-
-ifeq ($(strip $(OLED_ENABLE)), yes)
-    OPT_DEFS += -DOLED_ENABLE
-endif
-
-ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
-    OPT_DEFS += -DLOCAL_GLCDFONT
-endif
-
-ifeq ($(strip $(AUDIO_ENABLE)),yes)
-  ifeq ($(strip $(RGBLIGHT_ENABLE)),yes)
-    Link_Time_Optimization = yes
-  endif
-  ifeq ($(strip $(OLED_ENABLE)),yes)
-    Link_Time_Optimization = yes
-  endif
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-    EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
-endif
+include $(dir $(lastword $(MAKEFILE_LIST)))../../keymaps_common.mk
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/helix/pico/keymaps_common.mk
+++ b/keyboards/helix/pico/keymaps_common.mk
@@ -1,0 +1,76 @@
+### Helix Pico keyboard 'MAP_NAME' keymap: convenient command line option
+##    make HELIX=<options> helix/pico:MAP_NAME
+##    option= oled | back | under | na | ios
+##    ex.
+##      make HELIX=oled          helix/pico:MAP_NAME
+##      make HELIX=oled,back     helix/pico:MAP_NAME
+##      make HELIX=oled,under    helix/pico:MAP_NAME
+##      make HELIX=oled,back,na  helix/pico:MAP_NAME
+##      make HELIX=oled,back,ios helix/pico:MAP_NAME
+##
+ifneq ($(strip $(HELIX)),)
+  ifeq ($(findstring oled,$(HELIX)), oled)
+    OLED_ENABLE = yes
+  endif
+  ifeq ($(findstring back,$(HELIX)), back)
+    LED_BACK_ENABLE = yes
+  else ifeq ($(findstring under,$(HELIX)), under)
+    LED_UNDERGLOW_ENABLE = yes
+  endif
+  ifeq ($(findstring na,$(HELIX)), na)
+    LED_ANIMATIONS = no
+  endif
+  ifeq ($(findstring ios,$(HELIX)), ios)
+    IOS_DEVICE_ENABLE = yes
+  endif
+  $(eval $(call HELIX_CUSTOMISE_MSG))
+  $(info )
+endif
+
+# Uncomment these for checking
+#   jp: コンパイル時にカスタマイズの状態を表示したい時はコメントをはずします。
+#   jp: 上記の HELIX= でコマンドライン上でカスタマイズを指定した場合は常にカスタマイズの状態を表示されます。
+# $(eval $(call HELIX_CUSTOMISE_MSG))
+# $(info )
+
+ifeq ($(strip $(LED_BACK_ENABLE)), yes)
+  RGBLIGHT_ENABLE = yes
+  OPT_DEFS += -DRGBLED_BACK
+  ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
+    $(eval $(call HELIX_CUSTOMISE_MSG))
+    $(error LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE both 'yes')
+  endif
+else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
+  RGBLIGHT_ENABLE = yes
+else
+  RGBLIGHT_ENABLE = no
+endif
+
+ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
+    OPT_DEFS += -DIOS_DEVICE_ENABLE
+endif
+
+ifeq ($(strip $(LED_ANIMATIONS)), yes)
+    OPT_DEFS += -DRGBLIGHT_ANIMATIONS
+endif
+
+ifeq ($(strip $(OLED_ENABLE)), yes)
+    OPT_DEFS += -DOLED_ENABLE
+endif
+
+ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
+    OPT_DEFS += -DLOCAL_GLCDFONT
+endif
+
+ifeq ($(strip $(AUDIO_ENABLE)),yes)
+  ifeq ($(strip $(RGBLIGHT_ENABLE)),yes)
+    Link_Time_Optimization = yes
+  endif
+  ifeq ($(strip $(OLED_ENABLE)),yes)
+    Link_Time_Optimization = yes
+  endif
+endif
+
+ifeq ($(strip $(Link_Time_Optimization)),yes)
+    EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
+endif

--- a/keyboards/helix/rev2/keymaps/default/rules.mk
+++ b/keyboards/helix/rev2/keymaps/default/rules.mk
@@ -31,7 +31,7 @@ endef
 #  jp: 以下の7つの変数を必要に応じて編集します。
 HELIX_ROWS = 5              # Helix Rows is 4 or 5
 OLED_ENABLE = no            # OLED_ENABLE
-LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" insted of "common/glcdfont.c"
+LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" instead of "common/glcdfont.c"
 LED_BACK_ENABLE = no        # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations

--- a/keyboards/helix/rev2/keymaps/default/rules.mk
+++ b/keyboards/helix/rev2/keymaps/default/rules.mk
@@ -42,78 +42,16 @@ Link_Time_Optimization = no # if firmware size over limit, try this option
 ####    Do not enable these with audio at the same time.
 
 ### Helix keyboard 'default' keymap: convenient command line option
-##    make HELIX=<options> helix:defualt
+##    make HELIX=<options> helix:default
 ##    option= oled | back | under | na | ios
 ##    ex.
-##      make HELIX=oled          helix:defualt
-##      make HELIX=oled,back     helix:defualt
-##      make HELIX=oled,under    helix:defualt
-##      make HELIX=oled,back,na  helix:defualt
-##      make HELIX=oled,back,ios helix:defualt
+##      make HELIX=oled          helix:default
+##      make HELIX=oled,back     helix:default
+##      make HELIX=oled,under    helix:default
+##      make HELIX=oled,back,na  helix:default
+##      make HELIX=oled,back,ios helix:default
 ##
-ifneq ($(strip $(HELIX)),)
-  ifeq ($(findstring oled,$(HELIX)), oled)
-    OLED_ENABLE = yes
-  endif
-  ifeq ($(findstring back,$(HELIX)), back)
-    LED_BACK_ENABLE = yes
-  else ifeq ($(findstring under,$(HELIX)), under)
-    LED_UNDERGLOW_ENABLE = yes
-  endif
-  ifeq ($(findstring na,$(HELIX)), na)
-    LED_ANIMATIONS = no
-  endif
-  ifeq ($(findstring ios,$(HELIX)), ios)
-    IOS_DEVICE_ENABLE = yes
-  endif
-  $(eval $(call HELIX_CUSTOMISE_MSG))
-  $(info )
-endif
-
-# Uncomment these for checking
-#   jp: コンパイル時にカスタマイズの状態を表示したい時はコメントをはずします。
-# $(eval $(call HELIX_CUSTOMISE_MSG))
-# $(info )
-
-ifneq ($(strip $(HELIX_ROWS)), 4)
-  ifneq ($(strip $(HELIX_ROWS)), 5)
-    $(error HELIX_ROWS = $(strip $(HELIX_ROWS)) is unexpected value)
-  endif
-endif
-OPT_DEFS += -DHELIX_ROWS=$(strip $(HELIX_ROWS))
-
-ifeq ($(strip $(LED_BACK_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-  OPT_DEFS += -DRGBLED_BACK
-  ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-    $(eval $(call HELIX_CUSTOMISE_MSG))
-    $(error LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE both 'yes')
-  endif
-else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-else
-  RGBLIGHT_ENABLE = no
-endif
-
-ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
-    OPT_DEFS += -DIOS_DEVICE_ENABLE
-endif
-
-ifeq ($(strip $(LED_ANIMATIONS)), yes)
-    OPT_DEFS += -DRGBLIGHT_ANIMATIONS
-endif
-
-ifeq ($(strip $(OLED_ENABLE)), yes)
-    OPT_DEFS += -DOLED_ENABLE
-endif
-
-ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
-    OPT_DEFS += -DLOCAL_GLCDFONT
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-    EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
-endif
+include $(dir $(lastword $(MAKEFILE_LIST)))../../keymaps_common.mk
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/helix/rev2/keymaps/edvorakjp/rules.mk
+++ b/keyboards/helix/rev2/keymaps/edvorakjp/rules.mk
@@ -50,72 +50,20 @@ Link_Time_Optimization = no # if firmware size over limit, try this option
 ##      make HELIX=oled,back,na  helix:edvorakjp
 ##      make HELIX=oled,back,ios helix:edvorakjp
 ##
-ifneq ($(strip $(HELIX)),)
-  ifeq ($(findstring oled,$(HELIX)), oled)
-    OLED_ENABLE = yes
-  endif
-  ifeq ($(findstring back,$(HELIX)), back)
-    LED_BACK_ENABLE = yes
-  else ifeq ($(findstring under,$(HELIX)), under)
-    LED_UNDERGLOW_ENABLE = yes
-  endif
-  ifeq ($(findstring na,$(HELIX)), na)
-    LED_ANIMATIONS = no
-  endif
-  ifeq ($(findstring ios,$(HELIX)), ios)
-    IOS_DEVICE_ENABLE = yes
-  endif
-  $(eval $(call HELIX_CUSTOMISE_MSG))
-  $(info )
-endif
-
-# Uncomment these for checking
-#   jp: コンパイル時にカスタマイズの状態を表示したい時はコメントをはずします。
-# $(eval $(call HELIX_CUSTOMISE_MSG))
-# $(info )
+include $(dir $(lastword $(MAKEFILE_LIST)))../../keymaps_common.mk
 
 ifeq ($(strip $(HELIX_ROWS)), 4)
   SRC += keymap_4rows.c
 else ifeq ($(strip $(HELIX_ROWS)), 5)
   SRC += keymap_5rows.c
-else
-  $(error HELIX_ROWS = $(strip $(HELIX_ROWS)) is unexpected value)
 endif
-OPT_DEFS += -DHELIX_ROWS=$(strip $(HELIX_ROWS))
 
-ifeq ($(strip $(LED_BACK_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
+ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
   OPT_DEFS += -DRGBLED_BACK
-  ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-    $(eval $(call HELIX_CUSTOMISE_MSG))
-    $(error LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE both 'yes')
-  endif
-else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-  OPT_DEFS += -DRGBLED_BACK
-else
-  RGBLIGHT_ENABLE = no
-endif
-
-ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
-  OPT_DEFS += -DIOS_DEVICE_ENABLE
-endif
-
-ifeq ($(strip $(LED_ANIMATIONS)), yes)
-  OPT_DEFS += -DRGBLIGHT_ANIMATIONS
 endif
 
 ifeq ($(strip $(OLED_ENABLE)), yes)
-  OPT_DEFS += -DOLED_ENABLE
   SRC += oled.c
-endif
-
-ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
-  OPT_DEFS += -DLOCAL_GLCDFONT
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-    EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
 endif
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE

--- a/keyboards/helix/rev2/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows/rules.mk
@@ -26,10 +26,11 @@ define HELIX_CUSTOMISE_MSG
   $(info -  IOS_DEVICE_ENABLE=$(IOS_DEVICE_ENABLE))
 endef
 
+HELIX_ROWS = 5              # Helix keymap five_rows's Rows only 5
+
 # Helix keyboard customize
-# you can edit follows 7 Variables
-#  jp: 以下の7つの変数を必要に応じて編集します。
-HELIX_ROWS = 5              # Helix Rows is 4 or 5
+# you can edit follows 6 Variables
+#  jp: 以下の6つの変数を必要に応じて編集します。
 OLED_ENABLE = no            # OLED_ENABLE
 LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" instead of "common/glcdfont.c"
 LED_BACK_ENABLE = no        # LED backlight (Enable WS2812 RGB underlight.)
@@ -40,6 +41,10 @@ Link_Time_Optimization = no # if firmware size over limit, try this option
 
 ####  LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE.
 ####    Do not enable these with audio at the same time.
+
+ifneq ($(strip $(HELIX_ROWS)), 5)
+  $(error HELIX_ROWS = $(strip $(HELIX_ROWS)) is unexpected value)
+endif
 
 ### Helix keyboard 'five_rows' keymap: convenient command line option
 ##    make HELIX=<options> helix:five_rows
@@ -76,9 +81,9 @@ endif
 # $(info )
 
 ifneq ($(strip $(HELIX_ROWS)), 4)
-ifneq ($(strip $(HELIX_ROWS)), 5)
-$(error HELIX_ROWS = $(strip $(HELIX_ROWS)) is unexpected value)
-endif
+  ifneq ($(strip $(HELIX_ROWS)), 5)
+    $(error HELIX_ROWS = $(strip $(HELIX_ROWS)) is unexpected value)
+  endif
 endif
 OPT_DEFS += -DHELIX_ROWS=$(strip $(HELIX_ROWS))
 

--- a/keyboards/helix/rev2/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows/rules.mk
@@ -31,7 +31,7 @@ endef
 #  jp: 以下の7つの変数を必要に応じて編集します。
 HELIX_ROWS = 5              # Helix Rows is 4 or 5
 OLED_ENABLE = no            # OLED_ENABLE
-LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" insted of "common/glcdfont.c"
+LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" instead of "common/glcdfont.c"
 LED_BACK_ENABLE = no        # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations

--- a/keyboards/helix/rev2/keymaps/five_rows/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows/rules.mk
@@ -56,69 +56,7 @@ endif
 ##      make HELIX=oled,back,na  helix:five_rows
 ##      make HELIX=oled,back,ios helix:five_rows
 ##
-ifneq ($(strip $(HELIX)),)
-  ifeq ($(findstring oled,$(HELIX)), oled)
-    OLED_ENABLE = yes
-  endif
-  ifeq ($(findstring back,$(HELIX)), back)
-    LED_BACK_ENABLE = yes
-  else ifeq ($(findstring under,$(HELIX)), under)
-    LED_UNDERGLOW_ENABLE = yes
-  endif
-  ifeq ($(findstring na,$(HELIX)), na)
-    LED_ANIMATIONS = no
-  endif
-  ifeq ($(findstring ios,$(HELIX)), ios)
-    IOS_DEVICE_ENABLE = yes
-  endif
-  $(eval $(call HELIX_CUSTOMISE_MSG))
-  $(info )
-endif
-
-# Uncomment these for checking
-#   jp: コンパイル時にカスタマイズの状態を表示したい時はコメントをはずします。
-# $(eval $(call HELIX_CUSTOMISE_MSG))
-# $(info )
-
-ifneq ($(strip $(HELIX_ROWS)), 4)
-  ifneq ($(strip $(HELIX_ROWS)), 5)
-    $(error HELIX_ROWS = $(strip $(HELIX_ROWS)) is unexpected value)
-  endif
-endif
-OPT_DEFS += -DHELIX_ROWS=$(strip $(HELIX_ROWS))
-
-ifeq ($(strip $(LED_BACK_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-  OPT_DEFS += -DRGBLED_BACK
-  ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-    $(eval $(call HELIX_CUSTOMISE_MSG))
-    $(error LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE both 'yes')
-  endif
-else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-else
-  RGBLIGHT_ENABLE = no
-endif
-
-ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
-    OPT_DEFS += -DIOS_DEVICE_ENABLE
-endif
-
-ifeq ($(strip $(LED_ANIMATIONS)), yes)
-    OPT_DEFS += -DRGBLIGHT_ANIMATIONS
-endif
-
-ifeq ($(strip $(OLED_ENABLE)), yes)
-    OPT_DEFS += -DOLED_ENABLE
-endif
-
-ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
-    OPT_DEFS += -DLOCAL_GLCDFONT
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-    EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
-endif
+include $(dir $(lastword $(MAKEFILE_LIST)))../../keymaps_common.mk
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/helix/rev2/keymaps/five_rows_jis/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows_jis/rules.mk
@@ -31,7 +31,7 @@ endef
 #  jp: 以下の7つの変数を必要に応じて編集します。
 HELIX_ROWS = 5              # Helix Rows is 4 or 5
 OLED_ENABLE = no            # OLED_ENABLE
-LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" insted of "common/glcdfont.c"
+LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" instead of "common/glcdfont.c"
 LED_BACK_ENABLE = no        # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations

--- a/keyboards/helix/rev2/keymaps/five_rows_jis/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows_jis/rules.mk
@@ -41,79 +41,17 @@ Link_Time_Optimization = no # if firmware size over limit, try this option
 ####  LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE.
 ####    Do not enable these with audio at the same time.
 
-### Helix keyboard 'default' keymap: convenient command line option
-##    make HELIX=<options> helix:defualt
+### Helix keyboard 'five_rows_jis' keymap: convenient command line option
+##    make HELIX=<options> helix:five_rows
 ##    option= oled | back | under | na | ios
 ##    ex.
-##      make HELIX=oled          helix:defualt
-##      make HELIX=oled,back     helix:defualt
-##      make HELIX=oled,under    helix:defualt
-##      make HELIX=oled,back,na  helix:defualt
-##      make HELIX=oled,back,ios helix:defualt
+##      make HELIX=oled          helix:five_rows_jis
+##      make HELIX=oled,back     helix:five_rows_jis
+##      make HELIX=oled,under    helix:five_rows_jis
+##      make HELIX=oled,back,na  helix:five_rows_jis
+##      make HELIX=oled,back,ios helix:five_rows_jis
 ##
-ifneq ($(strip $(HELIX)),)
-  ifeq ($(findstring oled,$(HELIX)), oled)
-    OLED_ENABLE = yes
-  endif
-  ifeq ($(findstring back,$(HELIX)), back)
-    LED_BACK_ENABLE = yes
-  else ifeq ($(findstring under,$(HELIX)), under)
-    LED_UNDERGLOW_ENABLE = yes
-  endif
-  ifeq ($(findstring na,$(HELIX)), na)
-    LED_ANIMATIONS = no
-  endif
-  ifeq ($(findstring ios,$(HELIX)), ios)
-    IOS_DEVICE_ENABLE = yes
-  endif
-  $(eval $(call HELIX_CUSTOMISE_MSG))
-  $(info )
-endif
-
-# Uncomment these for checking
-#   jp: コンパイル時にカスタマイズの状態を表示したい時はコメントをはずします。
-# $(eval $(call HELIX_CUSTOMISE_MSG))
-# $(info )
-
-ifneq ($(strip $(HELIX_ROWS)), 4)
-  ifneq ($(strip $(HELIX_ROWS)), 5)
-    $(error HELIX_ROWS = $(strip $(HELIX_ROWS)) is unexpected value)
-  endif
-endif
-OPT_DEFS += -DHELIX_ROWS=$(strip $(HELIX_ROWS))
-
-ifeq ($(strip $(LED_BACK_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-  OPT_DEFS += -DRGBLED_BACK
-  ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-    $(eval $(call HELIX_CUSTOMISE_MSG))
-    $(error LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE both 'yes')
-  endif
-else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-else
-  RGBLIGHT_ENABLE = no
-endif
-
-ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
-    OPT_DEFS += -DIOS_DEVICE_ENABLE
-endif
-
-ifeq ($(strip $(LED_ANIMATIONS)), yes)
-    OPT_DEFS += -DRGBLIGHT_ANIMATIONS
-endif
-
-ifeq ($(strip $(OLED_ENABLE)), yes)
-    OPT_DEFS += -DOLED_ENABLE
-endif
-
-ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
-    OPT_DEFS += -DLOCAL_GLCDFONT
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-    EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
-endif
+include $(dir $(lastword $(MAKEFILE_LIST)))../../keymaps_common.mk
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/helix/rev2/keymaps/froggy/rules.mk
+++ b/keyboards/helix/rev2/keymaps/froggy/rules.mk
@@ -41,79 +41,17 @@ Link_Time_Optimization = no # if firmware size over limit, try this option
 ####  LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE.
 ####    Do not enable these with audio at the same time.
 
-### Helix keyboard 'default' keymap: convenient command line option
+### Helix keyboard 'froggy' keymap: convenient command line option
 ##    make HELIX=<options> helix:defualt
 ##    option= oled | back | under | na | ios
 ##    ex.
-##      make HELIX=oled          helix:defualt
-##      make HELIX=oled,back     helix:defualt
-##      make HELIX=oled,under    helix:defualt
-##      make HELIX=oled,back,na  helix:defualt
-##      make HELIX=oled,back,ios helix:defualt
+##      make HELIX=oled          helix:froggy
+##      make HELIX=oled,back     helix:froggy
+##      make HELIX=oled,under    helix:froggy
+##      make HELIX=oled,back,na  helix:froggy
+##      make HELIX=oled,back,ios helix:froggy
 ##
-ifneq ($(strip $(HELIX)),)
-  ifeq ($(findstring oled,$(HELIX)), oled)
-    OLED_ENABLE = yes
-  endif
-  ifeq ($(findstring back,$(HELIX)), back)
-    LED_BACK_ENABLE = yes
-  else ifeq ($(findstring under,$(HELIX)), under)
-    LED_UNDERGLOW_ENABLE = yes
-  endif
-  ifeq ($(findstring na,$(HELIX)), na)
-    LED_ANIMATIONS = no
-  endif
-  ifeq ($(findstring ios,$(HELIX)), ios)
-    IOS_DEVICE_ENABLE = yes
-  endif
-  $(eval $(call HELIX_CUSTOMISE_MSG))
-  $(info )
-endif
-
-# Uncomment these for checking
-#   jp: コンパイル時にカスタマイズの状態を表示したい時はコメントをはずします。
-# $(eval $(call HELIX_CUSTOMISE_MSG))
-# $(info )
-
-ifneq ($(strip $(HELIX_ROWS)), 4)
-  ifneq ($(strip $(HELIX_ROWS)), 5)
-    $(error HELIX_ROWS = $(strip $(HELIX_ROWS)) is unexpected value)
-  endif
-endif
-OPT_DEFS += -DHELIX_ROWS=$(strip $(HELIX_ROWS))
-
-ifeq ($(strip $(LED_BACK_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-  OPT_DEFS += -DRGBLED_BACK
-  ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-    $(eval $(call HELIX_CUSTOMISE_MSG))
-    $(error LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE both 'yes')
-  endif
-else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-else
-  RGBLIGHT_ENABLE = no
-endif
-
-ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
-    OPT_DEFS += -DIOS_DEVICE_ENABLE
-endif
-
-ifeq ($(strip $(LED_ANIMATIONS)), yes)
-    OPT_DEFS += -DRGBLIGHT_ANIMATIONS
-endif
-
-ifeq ($(strip $(OLED_ENABLE)), yes)
-    OPT_DEFS += -DOLED_ENABLE
-endif
-
-ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
-    OPT_DEFS += -DLOCAL_GLCDFONT
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-    EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
-endif
+include $(dir $(lastword $(MAKEFILE_LIST)))../../keymaps_common.mk
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/helix/rev2/keymaps/froggy/rules.mk
+++ b/keyboards/helix/rev2/keymaps/froggy/rules.mk
@@ -31,7 +31,7 @@ endef
 #  jp: 以下の7つの変数を必要に応じて編集します。
 HELIX_ROWS = 5              # Helix Rows is 4 or 5
 OLED_ENABLE = yes            # OLED_ENABLE
-LOCAL_GLCDFONT = yes         # use each keymaps "helixfont.h" insted of "common/glcdfont.c"
+LOCAL_GLCDFONT = yes         # use each keymaps "helixfont.h" instead of "common/glcdfont.c"
 LED_BACK_ENABLE = yes        # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations

--- a/keyboards/helix/rev2/keymaps/led_test/rules.mk
+++ b/keyboards/helix/rev2/keymaps/led_test/rules.mk
@@ -43,79 +43,17 @@ Link_Time_Optimization = no # if firmware size over limit, try this option
 
 SRC += led_test_init.c
 
-### Helix keyboard 'default' keymap: convenient command line option
+### Helix keyboard 'led_test' keymap: convenient command line option
 ##    make HELIX=<options> helix:defualt
 ##    option= oled | back | under | na | ios
 ##    ex.
-##      make HELIX=oled          helix:defualt
-##      make HELIX=oled,back     helix:defualt
-##      make HELIX=oled,under    helix:defualt
-##      make HELIX=oled,back,na  helix:defualt
-##      make HELIX=oled,back,ios helix:defualt
+##      make HELIX=oled          helix:led_test
+##      make HELIX=oled,back     helix:led_test
+##      make HELIX=oled,under    helix:led_test
+##      make HELIX=oled,back,na  helix:led_test
+##      make HELIX=oled,back,ios helix:led_test
 ##
-ifneq ($(strip $(HELIX)),)
-  ifeq ($(findstring oled,$(HELIX)), oled)
-    OLED_ENABLE = yes
-  endif
-  ifeq ($(findstring back,$(HELIX)), back)
-    LED_BACK_ENABLE = yes
-  else ifeq ($(findstring under,$(HELIX)), under)
-    LED_UNDERGLOW_ENABLE = yes
-  endif
-  ifeq ($(findstring na,$(HELIX)), na)
-    LED_ANIMATIONS = no
-  endif
-  ifeq ($(findstring ios,$(HELIX)), ios)
-    IOS_DEVICE_ENABLE = yes
-  endif
-  $(eval $(call HELIX_CUSTOMISE_MSG))
-  $(info )
-endif
-
-# Uncomment these for checking
-#   jp: コンパイル時にカスタマイズの状態を表示したい時はコメントをはずします。
-# $(eval $(call HELIX_CUSTOMISE_MSG))
-# $(info )
-
-ifneq ($(strip $(HELIX_ROWS)), 4)
-  ifneq ($(strip $(HELIX_ROWS)), 5)
-    $(error HELIX_ROWS = $(strip $(HELIX_ROWS)) is unexpected value)
-  endif
-endif
-OPT_DEFS += -DHELIX_ROWS=$(strip $(HELIX_ROWS))
-
-ifeq ($(strip $(LED_BACK_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-  OPT_DEFS += -DRGBLED_BACK
-  ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-    $(eval $(call HELIX_CUSTOMISE_MSG))
-    $(error LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE both 'yes')
-  endif
-else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
-  RGBLIGHT_ENABLE = yes
-else
-  RGBLIGHT_ENABLE = no
-endif
-
-ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
-    OPT_DEFS += -DIOS_DEVICE_ENABLE
-endif
-
-ifeq ($(strip $(LED_ANIMATIONS)), yes)
-    OPT_DEFS += -DRGBLIGHT_ANIMATIONS
-endif
-
-ifeq ($(strip $(OLED_ENABLE)), yes)
-    OPT_DEFS += -DOLED_ENABLE
-endif
-
-ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
-    OPT_DEFS += -DLOCAL_GLCDFONT
-endif
-
-ifeq ($(strip $(Link_Time_Optimization)),yes)
-    EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
-endif
+include $(dir $(lastword $(MAKEFILE_LIST)))../../keymaps_common.mk
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/helix/rev2/keymaps/led_test/rules.mk
+++ b/keyboards/helix/rev2/keymaps/led_test/rules.mk
@@ -31,7 +31,7 @@ endef
 #  jp: 以下の7つの変数を必要に応じて編集します。
 HELIX_ROWS = 5              # Helix Rows is 4 or 5
 OLED_ENABLE = yes            # OLED_ENABLE
-LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" insted of "common/glcdfont.c"
+LOCAL_GLCDFONT = no         # use each keymaps "helixfont.h" instead of "common/glcdfont.c"
 LED_BACK_ENABLE = yes        # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations

--- a/keyboards/helix/rev2/keymaps/led_test/rules.mk
+++ b/keyboards/helix/rev2/keymaps/led_test/rules.mk
@@ -41,6 +41,8 @@ Link_Time_Optimization = no # if firmware size over limit, try this option
 ####  LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE.
 ####    Do not enable these with audio at the same time.
 
+SRC += led_test_init.c
+
 ### Helix keyboard 'default' keymap: convenient command line option
 ##    make HELIX=<options> helix:defualt
 ##    option= oled | back | under | na | ios
@@ -114,8 +116,6 @@ endif
 ifeq ($(strip $(Link_Time_Optimization)),yes)
     EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
 endif
-
-SRC += led_test_init.c
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/keyboards/helix/rev2/keymaps_common.mk
+++ b/keyboards/helix/rev2/keymaps_common.mk
@@ -1,0 +1,79 @@
+##
+## Helix keyboard rev2 common compile option process
+##
+
+### Helix keyboard 'MAP_NAME' keymap: convenient command line option
+##    make HELIX=<options> helix:MAP_NAME
+##    option= oled | back | under | na | ios
+##    ex.
+##      make HELIX=oled          helix:MAP_NAME
+##      make HELIX=oled,back     helix:MAP_NAME
+##      make HELIX=oled,under    helix:MAP_NAME
+##      make HELIX=oled,back,na  helix:MAP_NAME
+##      make HELIX=oled,back,ios helix:MAP_NAME
+##
+ifneq ($(strip $(HELIX)),)
+  ifeq ($(findstring oled,$(HELIX)), oled)
+    OLED_ENABLE = yes
+  endif
+  ifeq ($(findstring back,$(HELIX)), back)
+    LED_BACK_ENABLE = yes
+  else ifeq ($(findstring under,$(HELIX)), under)
+    LED_UNDERGLOW_ENABLE = yes
+  endif
+  ifeq ($(findstring na,$(HELIX)), na)
+    LED_ANIMATIONS = no
+  endif
+  ifeq ($(findstring ios,$(HELIX)), ios)
+    IOS_DEVICE_ENABLE = yes
+  endif
+  $(eval $(call HELIX_CUSTOMISE_MSG))
+  $(info )
+endif
+
+# Uncomment these for checking
+#   jp: コンパイル時にカスタマイズの状態を表示したい時はコメントをはずします。
+#   jp: 上記の HELIX= でコマンドライン上でカスタマイズを指定した場合は常にカスタマイズの状態を表示されます。
+# $(eval $(call HELIX_CUSTOMISE_MSG))
+# $(info )
+
+ifneq ($(strip $(HELIX_ROWS)), 4)
+  ifneq ($(strip $(HELIX_ROWS)), 5)
+    $(error HELIX_ROWS = $(strip $(HELIX_ROWS)) is unexpected value)
+  endif
+endif
+OPT_DEFS += -DHELIX_ROWS=$(strip $(HELIX_ROWS))
+
+ifeq ($(strip $(LED_BACK_ENABLE)), yes)
+  RGBLIGHT_ENABLE = yes
+  OPT_DEFS += -DRGBLED_BACK
+  ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
+    $(eval $(call HELIX_CUSTOMISE_MSG))
+    $(error LED_BACK_ENABLE and LED_UNDERGLOW_ENABLE both 'yes')
+  endif
+else ifeq ($(strip $(LED_UNDERGLOW_ENABLE)), yes)
+  RGBLIGHT_ENABLE = yes
+else
+  RGBLIGHT_ENABLE = no
+endif
+
+ifeq ($(strip $(IOS_DEVICE_ENABLE)), yes)
+    OPT_DEFS += -DIOS_DEVICE_ENABLE
+endif
+
+ifeq ($(strip $(LED_ANIMATIONS)), yes)
+    OPT_DEFS += -DRGBLIGHT_ANIMATIONS
+endif
+
+ifeq ($(strip $(OLED_ENABLE)), yes)
+    OPT_DEFS += -DOLED_ENABLE
+endif
+
+ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
+    OPT_DEFS += -DLOCAL_GLCDFONT
+endif
+
+ifeq ($(strip $(Link_Time_Optimization)),yes)
+    EXTRAFLAGS += -flto -DUSE_Link_Time_Optimization
+endif
+


### PR DESCRIPTION
helix/[rev2|pico]/keymaps/*/rules.mk の後半がどれも同じ記述なので、helix/[rev2|pico]/keymaps_common.mk に集約するようにしました。

変更前と変更後で作成されるバイナリに変化がないことは rev2, pico の全部のキーマップで確認済みです。