### PR TITLE
update helix's readmes. All the ':avrdude' was replaced with ':flash'.

### DIFF
--- a/keyboards/helix/pico/keymaps/default/readme.md
+++ b/keyboards/helix/pico/keymaps/default/readme.md
@@ -118,16 +118,14 @@ $ make helix/pico:default
 $ make helix/pico/back:default               # with backlight
 $ make HELIX=no_ani helix/pico/back:default  # with backlight without animation
 $ make helix/pico/under:default              # with underglow
-$ make helix/pico/oled:default               # with oled
 ```
 
 flash to keyboard
 ```
-$ make helix/pico:default:avrdude
-$ make helix/pico/back:default:avrdude       # with backlight
-$ make HELIX=no_ani helix/pico/back:default:avrdude  # with backlight without animation
-$ make helix/pico/under:default:avrdude      # with underglow
-$ make helix/pico/oled:default:avrdude       # with oled
+$ make helix/pico:default:flash
+$ make helix/pico/back:default:flash               # with backlight
+$ make HELIX=no_ani helix/pico/back:default:flash  # with backlight without animation
+$ make helix/pico/under:default:flash              # with underglow
 
 ```
 

--- a/keyboards/helix/pico/keymaps/default/readme_jp.md
+++ b/keyboards/helix/pico/keymaps/default/readme_jp.md
@@ -118,10 +118,10 @@ qmk_firmwareでは各キーボードのコンパイルは、`<キーボード名
 $ make helix/pico:default
 ```
 
-キーボードへの書き込みまで同時に行うには下記のように`:avrdude`を付けます。
+キーボードへの書き込みまで同時に行うには下記のように`:flash`を付けます。
 
 ```
-$ make helix/pico:default:avrdude
+$ make helix/pico:default:flash
 ```
 
 コンパイル結果と中間生成物を消去したい場合は以下のようにします。
@@ -132,19 +132,14 @@ $ make helix/pico:default:clean
 
 上記の、rules.mk によるカスタマイズ項目の一部は下記のようにコマンド上で直接指定することも可能です。
 
-OLED を有効にしてコンパイルしてキーボードへの書き込む。
-```
-$ make helix/pico/oled:default:avrdude
-```
-
 RGB バックライトを有効にしてコンパイルしてキーボードへ書き込む。
 ```
-$ make helix/pico/back:default:avrdude
+$ make helix/pico/back:default:flash
 ```
 
 RGB Underglow を有効にしてコンパイルしてキーボードへ書き込む。
 ```
-$ make helix/pico/under:default:avrdude
+$ make helix/pico/under:default:flash
 ```
 
 ## リンク

--- a/keyboards/helix/rev2/keymaps/default/readme.md
+++ b/keyboards/helix/rev2/keymaps/default/readme.md
@@ -139,13 +139,13 @@ $ make helix/rev2/oled/under:default         # with oled and underglow
 
 flash to keyboard
 ```
-$ make helix:default:avrdude
-$ make helix/rev2/back:default:avrdude       # with backlight
-$ make HELIX=no_ani helix/rev2/back:default:avrdude  # with backlight without animation
-$ make helix/rev2/under:default:avrdude      # with underglow
-$ make helix/rev2/oled:default:avrdude       # with oled
-$ make helix/rev2/oled/back:default:avrdude  # with oled and backlight
-$ make helix/rev2/oled/under:default:avrdude # with oled and underglow
+$ make helix:default:flash
+$ make helix/rev2/back:default:flash               # with backlight
+$ make HELIX=no_ani helix/rev2/back:default:flash  # with backlight without animation
+$ make helix/rev2/under:default:flash              # with underglow
+$ make helix/rev2/oled:default:flash               # with oled
+$ make helix/rev2/oled/back:default:flash          # with oled and backlight
+$ make helix/rev2/oled/under:default:flash         # with oled and underglow
 
 ```
 

--- a/keyboards/helix/rev2/keymaps/default/readme_jp.md
+++ b/keyboards/helix/rev2/keymaps/default/readme_jp.md
@@ -90,10 +90,10 @@ qmk_firmwareでは各キーボードのコンパイルは、`<キーボード名
 $ make helix:default
 ```
 
-キーボードへの書き込みまで同時に行うには下記のように`:avrdude`を付けます。
+キーボードへの書き込みまで同時に行うには下記のように`:flash`を付けます。
 
 ```
-$ make helix:default:avrdude
+$ make helix:default:flash
 ```
 
 コンパイル結果と中間生成物を消去したい場合は以下のようにします。
@@ -106,27 +106,27 @@ $ make helix:default:clean
 
 OLED を有効にしてコンパイルしてキーボードへの書き込む。
 ```
-$ make helix/rev2/oled:default:avrdude
+$ make helix/rev2/oled:default:flash
 ```
 
 RGB バックライトを有効にしてコンパイルしてキーボードへ書き込む。
 ```
-$ make helix/rev2/back:default:avrdude
+$ make helix/rev2/back:default:flash
 ```
 
 RGB Underglow を有効にしてコンパイルしてキーボードへ書き込む。
 ```
-$ make helix/rev2/under:default:avrdude
+$ make helix/rev2/under:default:flash
 ```
 
 OLED とRGB バックライトを有効にしてコンパイルしてキーボードへ書き込む。
 ```
-$ make helix/rev2/oled/back:default:avrdude
+$ make helix/rev2/oled/back:default:flash
 ```
 
 OLED とRGB Underglowを有効にしてコンパイルしてキーボードへ書き込む。
 ```
-$ make helix/rev2/oled/under:default:avrdude
+$ make helix/rev2/oled/under:default:flash
 ```
 
 ## リンク

--- a/keyboards/helix/rev2/keymaps/led_test/README.md
+++ b/keyboards/helix/rev2/keymaps/led_test/README.md
@@ -23,5 +23,5 @@ $ make helix:led_test
 
 Execute the 'make' command and press the reset switch on the keyboard.
 ```
-$ make helix:led_test:avrdude
+$ make helix:led_test:flash
 ```


### PR DESCRIPTION
#20 の追加のコミットです。説明はそちらのコメントに。