### PR TITLE
helix/rev2 SPLIT_HAND_MATRIX_GRID test

### DIFF
--- a/keyboards/helix/rev2/config.h
+++ b/keyboards/helix/rev2/config.h
@@ -38,10 +38,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SERIAL_USE_MULTI_TRANSACTION
 
 /* Select hand configuration */
+#define SPLIT_HAND_MATRIX_GRID D7,B2
 // #define MASTER_LEFT
 // #define MASTER_RIGHT
 // #define EE_HANDS
-#define SPLIT_HAND_MATRIX_GRID D7,B2
 
 // Helix keyboard OLED support
 //      see ./rules.mk: OLED_ENABLE=yes or no

--- a/keyboards/helix/rev2/config.h
+++ b/keyboards/helix/rev2/config.h
@@ -38,9 +38,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SERIAL_USE_MULTI_TRANSACTION
 
 /* Select hand configuration */
-#define MASTER_LEFT
+// #define MASTER_LEFT
 // #define MASTER_RIGHT
 // #define EE_HANDS
+#define SPLIT_HAND_MATRIX_GRID D7,B2
 
 // Helix keyboard OLED support
 //      see ./rules.mk: OLED_ENABLE=yes or no

--- a/keyboards/helix/rev2/rev2.c
+++ b/keyboards/helix/rev2/rev2.c
@@ -1,4 +1,5 @@
 #include "helix.h"
+#include "quantum.h"
 
 // Each keymap.c should use is_keyboard_master() instead of 'is_master'.
 // But keep 'is_master' for a while for backwards compatibility
@@ -39,3 +40,28 @@ void matrix_slave_scan_user(void) {
     matrix_scan_user();
 }
 #endif
+
+#ifdef SPLIT_HAND_MATRIX_GRID
+
+static uint8_t peek_matrix_intersection(pin_t out_pin, pin_t in_pin) {
+    setPinInputHigh(in_pin);
+    setPinOutput(out_pin);
+    writePinLow(out_pin);
+    // It's almost unnecessary, but wait until it's down to low, just in case.
+    wait_us(1);
+    uint8_t pin_state = readPin(in_pin);
+    // Set out_pin to a setting that is less susceptible to noise.
+    setPinInputHigh(out_pin);
+    wait_us(30);
+    return pin_state;
+}
+
+bool is_keyboard_left(void) {
+  #ifdef SPLIT_HAND_MATRIX_GRID_LOW_IS_RIGHT
+    return peek_matrix_intersection(SPLIT_HAND_MATRIX_GRID);
+  #else
+    return ! peek_matrix_intersection(SPLIT_HAND_MATRIX_GRID);
+  #endif
+}
+
+#endif /* SPLIT_HAND_MATRIX_GRID */

--- a/keyboards/helix/rev2/split_util.c
+++ b/keyboards/helix/rev2/split_util.c
@@ -7,7 +7,7 @@
 #include "split_util.h"
 #include "matrix.h"
 #include "keyboard.h"
-#include "quantum.h"
+#include "wait.h"
 
 #ifdef USE_MATRIX_I2C
 #  include "i2c.h"
@@ -44,32 +44,12 @@ bool waitForUsb(void) {
     return false;
 }
 
-#ifdef SPLIT_HAND_MATRIX_GRID
-static uint8_t peek_matrix_intersection(pin_t out_pin, pin_t in_pin) {
-    setPinInputHigh(in_pin);
-    setPinOutput(out_pin);
-    writePinLow(out_pin);
-    // It's almost unnecessary, but wait until it's down to low, just in case.
-    wait_us(1);
-    uint8_t pin_state = readPin(in_pin);
-    // Set out_pin to a setting that is less susceptible to noise.
-    setPinInputHigh(out_pin);
-    wait_us(30);
-    return pin_state;
-}
-#endif
-
+__attribute__((weak))
 bool is_keyboard_left(void) {
 #if defined(SPLIT_HAND_PIN)
     // Test pin SPLIT_HAND_PIN for High/Low, if low it's right hand
     setPinInput(SPLIT_HAND_PIN);
     return readPin(SPLIT_HAND_PIN);
-#elif defined(SPLIT_HAND_MATRIX_GRID)
-#   ifdef SPLIT_HAND_MATRIX_GRID_LOW_IS_RIGHT
-    return peek_matrix_intersection(SPLIT_HAND_MATRIX_GRID);
-#   else
-    return ! peek_matrix_intersection(SPLIT_HAND_MATRIX_GRID);
-#   endif
 #elif defined(EE_HANDS)
     return eeconfig_read_handedness();
 #elif defined(MASTER_RIGHT)

--- a/keyboards/helix/rev2/split_util.c
+++ b/keyboards/helix/rev2/split_util.c
@@ -7,7 +7,7 @@
 #include "split_util.h"
 #include "matrix.h"
 #include "keyboard.h"
-#include "wait.h"
+#include "quantum.h"
 
 #ifdef USE_MATRIX_I2C
 #  include "i2c.h"
@@ -44,12 +44,32 @@ bool waitForUsb(void) {
     return false;
 }
 
+#ifdef SPLIT_HAND_MATRIX_GRID
+static uint8_t peek_matrix_intersection(pin_t out_pin, pin_t in_pin) {
+    setPinInputHigh(in_pin);
+    setPinOutput(out_pin);
+    writePinLow(out_pin);
+    // It's almost unnecessary, but wait until it's down to low, just in case.
+    wait_us(1);
+    uint8_t pin_state = readPin(in_pin);
+    // Set out_pin to a setting that is less susceptible to noise.
+    setPinInputHigh(out_pin);
+    wait_us(30);
+    return pin_state;
+}
+#endif
 
 bool is_keyboard_left(void) {
 #if defined(SPLIT_HAND_PIN)
     // Test pin SPLIT_HAND_PIN for High/Low, if low it's right hand
     setPinInput(SPLIT_HAND_PIN);
     return readPin(SPLIT_HAND_PIN);
+#elif defined(SPLIT_HAND_MATRIX_GRID)
+#   ifdef SPLIT_HAND_MATRIX_GRID_LOW_IS_RIGHT
+    return peek_matrix_intersection(SPLIT_HAND_MATRIX_GRID);
+#   else
+    return ! peek_matrix_intersection(SPLIT_HAND_MATRIX_GRID);
+#   endif
 #elif defined(EE_HANDS)
     return eeconfig_read_handedness();
 #elif defined(MASTER_RIGHT)


### PR DESCRIPTION
## Description

キーマトリクスの空き交点で、左右を判定するコードできました。
qmk の方に split_common への変更として PR 出しておきましたが、簡単なコードなので、現行の Helix の split_util.c にも簡単に適応できることを示すサンプルとして、ドラフト PR としておいておきます。
