### PR TITLE
fix helix/pico/qmk_conf compile error

### DIFF
--- a/keyboards/helix/pico/qmk_conf/rules.mk
+++ b/keyboards/helix/pico/qmk_conf/rules.mk
@@ -1,5 +1,4 @@
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 AUDIO_ENABLE = yes          # Audio output on port B5
-LED_BACK_ENABLE = yes
 
 include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))


### PR DESCRIPTION
すみません。helix/pico/qmk_conf が容量不足でエラーが出ていました。